### PR TITLE
Add check for OK on URL ping

### DIFF
--- a/src/ping.js
+++ b/src/ping.js
@@ -25,12 +25,12 @@ export default async ({ url, route, knex, queue }) => {
   const pingRoute = route || '/_ping';
   const pingUrl = `${url}${pingRoute}`;
   try {
-    await axios({
+    const { data } = await axios({
       url: pingUrl,
       method: 'get',
     });
 
-    return { status: 200 };
+    return { status: data === 'OK' ? 200 : 500 };
   } catch (e) {
     return {
       status: 500,

--- a/test/healthcheck.spec.js
+++ b/test/healthcheck.spec.js
@@ -32,17 +32,17 @@ knexTracker.on('query', query => {
 });
 
 /* mocks */
-mock.onGet('http://service-1/_ping').reply(200);
-mock.onGet('http://service-2/_ping').reply(200);
-mock.onGet('http://service-3/_ping').reply(200);
-mock.onGet('http://service-4/_ping').reply(200);
+mock.onGet('http://service-1/_ping').reply(200, 'OK');
+mock.onGet('http://service-2/_ping').reply(200, 'OK');
+mock.onGet('http://service-3/_ping').reply(200, 'OK');
+mock.onGet('http://service-4/_ping').reply(200, 'OK');
 mock.onGet('http://service-5/_ping').reply(500);
 mock.onGet('http://service-6/_ping').reply(500);
 mock.onGet('http://service-7/_ping').reply(500);
-mock.onGet('http://service-8/_ping').reply(200);
-mock.onGet('http://service-9/_ping').reply(200);
-mock.onGet('http://service-10/health/ping').reply(200);
-mock.onGet('http://service-11/_custom-ping').reply(200);
+mock.onGet('http://service-8/_ping').reply(200, 'OK');
+mock.onGet('http://service-9/_ping').reply(200, 'OK');
+mock.onGet('http://service-10/health/ping').reply(200, 'OK');
+mock.onGet('http://service-11/_custom-ping').reply(200, 'OK');
 
 async function compareHealth(t, services, expectedHealth) {
   const health = await healthCheck(services);

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -18,17 +18,17 @@ import {
 
 const mock = new MockAdapter(axios);
 
-mock.onGet('http://service-1/_ping').reply(200);
-mock.onGet('http://service-2/_ping').reply(200);
-mock.onGet('http://service-3/_ping').reply(200);
-mock.onGet('http://service-4/_ping').reply(200);
+mock.onGet('http://service-1/_ping').reply(200, 'OK');
+mock.onGet('http://service-2/_ping').reply(200, 'OK');
+mock.onGet('http://service-3/_ping').reply(200, 'OK');
+mock.onGet('http://service-4/_ping').reply(200, 'OK');
 mock.onGet('http://service-5/_ping').reply(500);
 mock.onGet('http://service-6/_ping').reply(500);
 mock.onGet('http://service-7/_ping').reply(500);
-mock.onGet('http://service-8/_ping').reply(200);
+mock.onGet('http://service-8/_ping').reply(200, 'OK');
 mock.onGet('http://service-9/ping/health').reply(500);
-mock.onGet('http://service-10/health/ping').reply(200);
-mock.onGet('http://service-11/_custom-ping').reply(200);
+mock.onGet('http://service-10/health/ping').reply(200, 'OK');
+mock.onGet('http://service-11/_custom-ping').reply(200, 'OK');
 
 async function compareMiddlewareResponse(t, service, expected) {
   const app = express();

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -9,6 +9,7 @@ import {
   serviceTimeoutUrl,
   serviceNetworkErrorUrl,
   serviceCustomPingRoute,
+  servicePingNotOkBut200,
 } from './services';
 import {
   statusOK,
@@ -26,11 +27,12 @@ import {
 const mock = new MockAdapter(axios);
 
 /* mocks */
-mock.onGet(`${serviceUpUrl}/_ping`).reply(200);
+mock.onGet(`${serviceUpUrl}/_ping`).reply(200, 'OK');
 mock.onGet(`${serviceDownUrl}/_ping`).reply(500);
 mock.onGet(`${serviceTimeoutUrl}/_ping`).timeout();
 mock.onGet(`${serviceNetworkErrorUrl}/_ping`).networkError();
-mock.onGet(`${serviceCustomPingRoute}/_custom-ping`).reply(200);
+mock.onGet(`${serviceCustomPingRoute}/_custom-ping`).reply(200, 'OK');
+mock.onGet(`${servicePingNotOkBut200}/_ping`).reply(200);
 
 async function comparePing(t, service, expected) {
   const response = await ping(service);
@@ -52,6 +54,9 @@ feature('pinging an url', scenario => {
   });
   scenario('given that the url has a custom ping route', async t => {
     await comparePing(t, { url: serviceCustomPingRoute, route: '/_custom-ping' }, statusOK);
+  });
+  scenario('given that ping does not return ok', async t => {
+    await comparePing(t, { url: servicePingNotOkBut200 }, statusFail);
   });
 });
 

--- a/test/services.js
+++ b/test/services.js
@@ -66,6 +66,7 @@ const serviceDownUrl = 'http://service-down-dependencie';
 const serviceTimeoutUrl = 'http://service-timeout-dependencie';
 const serviceNetworkErrorUrl = 'http://service-nw-error-dependencie';
 const serviceCustomPingRoute = 'http://service-custom-ping-route';
+const servicePingNotOkBut200 = 'http://service-not-ok-but-200';
 
 module.exports = {
   serviceUpUrl,
@@ -85,4 +86,5 @@ module.exports = {
   servicesDatabaseHealth,
   servicesQueue,
   servicesQueueHealth,
+  servicePingNotOkBut200,
 };


### PR DESCRIPTION
Due to some bug, when pinging a service on docker would return 200 even
if the service was down, this will check if the response contains the
string `'OK'` on the response data, that only happens if the service
truly is up